### PR TITLE
Override gallery content

### DIFF
--- a/code/Block/Adminhtml/Catalog/Product/Helper/Form/Gallery/Content.php
+++ b/code/Block/Adminhtml/Catalog/Product/Helper/Form/Gallery/Content.php
@@ -1,0 +1,26 @@
+<?php
+
+class MVentory_CDN_Block_Adminhtml_Catalog_Product_Helper_Form_Gallery_Content extends Mage_Adminhtml_Block_Catalog_Product_Helper_Form_Gallery_Content {
+
+    public function getImagesJson()
+    {
+        $store = Mage::app()->getStore();
+
+        if(is_array($this->getElement()->getValue())) {
+            $value = $this->getElement()->getValue();
+            if(count($value['images'])>0) {
+                foreach ($value['images'] as &$image) {
+                    $image['url'] =
+                        $store->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA)
+                        . $store->getConfig(MVentory_CDN_Model_Config::PREFIX)
+                        . '/'
+                        . '100x100'
+                        . $image['file'];
+                }
+                return Mage::helper('core')->jsonEncode($value['images']);
+            }
+        }
+        return '[]';
+    }
+
+} 

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -84,7 +84,7 @@
               <label>Website Prefix</label>
               <frontend_type>text</frontend_type>
 
-              <show_in_default>0</show_in_default>
+              <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>
 


### PR DESCRIPTION
fixes #7 - override gallery content and use the default-prefix from the store
